### PR TITLE
Add AllowNullLiteral To FirestoreDocument

### DIFF
--- a/FsFirestore/Types.fs
+++ b/FsFirestore/Types.fs
@@ -13,6 +13,7 @@ module Types =
         |> Seq.exists (fun x -> x.AttributeType = typeof<FirestorePropertyAttribute>)
 
     /// Abstract base class for easier interaction with the API.
+    [<AllowNullLiteral>]
     [<AbstractClass>]
     type FirestoreDocument() =
         member val Id = "" with get, set 


### PR DESCRIPTION
The `document` function returns null when the document is missing then when trying to use it raises a null pointer exception. To use a `match doc with |null -> ... | _ -> ...` syntax the type must be nullable, the FirestoreDocument type is not so type inference does not allow it and we get a compilation error. There may be a better way to deal with this situation. But adding the `[<AllowNullLiteral>]` works.

```
 let createOrUpdate<'a, 'b when 'a :> FirestoreDocument and 'a: not struct and 'a: null>
        collection
        id
        create
        update
        (obj: 'b)
        =
        let doc : 'a = document<'a> collection id

        match doc with
        | null ->
            obj
            |> create
            |> updateDocument collection id
            |> info "createDoc "
        | _ ->
            doc
            |> update obj
            |> updateDocument collection id
            |> info "updateDoc "
```